### PR TITLE
Remove action mapping for ROS 1

### DIFF
--- a/mapping_rules.yaml
+++ b/mapping_rules.yaml
@@ -6,8 +6,3 @@
   ros1_service_name: 'TwoInts'
   ros2_package_name: 'example_interfaces'
   ros2_service_name: 'AddTwoInts'
--
-  ros1_package_name: 'actionlib_tutorials'
-  ros1_action_name: 'Fibonacci'
-  ros2_package_name: 'example_interfaces'
-  ros2_action_name: 'Fibonacci'


### PR DESCRIPTION
Removing until this feature is supported by the bridge.

@nuclearsandwich I think this should go in Crystal Patch 2.