### PR TITLE
Remove the action_msgs dependency CMake code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,12 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(action_msgs REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/Fibonacci.action"
   "srv/AddTwoInts.srv"
-  DEPENDENCIES action_msgs
 )
 
 install(FILES mapping_rules.yaml DESTINATION share/${PROJECT_NAME})


### PR DESCRIPTION
It is implicitly added by rosidl_generate_interfaces().

Connects to https://github.com/ros2/rosidl/pull/369.