### PR TITLE
add mapping for rospy_tutorials/AddTwoInts.srv

### DIFF
--- a/mapping_rules.yaml
+++ b/mapping_rules.yaml
@@ -6,3 +6,8 @@
   ros1_service_name: 'TwoInts'
   ros2_package_name: 'example_interfaces'
   ros2_service_name: 'AddTwoInts'
+-
+  ros1_package_name: 'rospy_tutorials'
+  ros1_service_name: 'AddTwoInts'
+  ros2_package_name: 'example_interfaces'
+  ros2_service_name: 'AddTwoInts'


### PR DESCRIPTION
Based on ros2/ros1_bridge#228 this package should also offer a mapping to `rospy_tutorials` and not only to `roscpp_tutorials`.

Linux packaging job: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=279)](https://ci.ros2.org/job/ci_packaging_linux/279/)