### PR TITLE
Change links from index.ros.org -> docs.ros.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@ ROS 2 examples
 ==============
 
 Tutorial on how to try out the examples: 
-* [Writing a simple service and client C++](https://index.ros.org/doc/ros2/Tutorials/Writing-A-Simple-Cpp-Service-And-Client/)
-* [Writing a simple service and client Python](https://index.ros.org/doc/ros2/Tutorials/Writing-A-Simple-Py-Service-And-Client/)
+* [Writing a simple service and client C++](https://docs.ros.org/en/rolling/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.html)
+* [Writing a simple service and client Python](https://docs.ros.org/en/rolling/Tutorials/Writing-A-Simple-Py-Service-And-Client.html)


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>