### PR TITLE
Remove action_msgs dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,8 +16,6 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <depend>action_msgs</depend>
-
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
It is now properly included in the rosidl dependency chain.

Depends on https://github.com/ros2/rosidl_defaults/pull/22